### PR TITLE
Wire up delete dataset button with generic confirmation dialog

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
       "jsx-a11y/click-events-have-key-events": 0,
       "jsx-a11y/no-static-element-interactions": 0,
       "function-paren-newline": 0,
+      "@typescript-eslint/unbound-method": 0
     },
 
     settings: {

--- a/packages/application-scripts/src/deleteDatasets.ts
+++ b/packages/application-scripts/src/deleteDatasets.ts
@@ -1,0 +1,18 @@
+import { unlinkSync } from "fs-extra";
+import { join } from "path";
+import { CONSTANTS } from "./constants";
+
+function deleteSingleDataset(path: string) {
+  try {
+    unlinkSync(path);
+  } catch {
+    // eslint-disable-next-line no-console
+    console.warn(`No such dataset ${path} exists. Skipping.`);
+  }
+}
+
+export function deleteDatasets(datasetNames: string[]) {
+  datasetNames.forEach(datasetName => {
+    deleteSingleDataset(join(CONSTANTS.OUTPUT_DIRECTORY, datasetName));
+  });
+}

--- a/packages/application-scripts/src/index.ts
+++ b/packages/application-scripts/src/index.ts
@@ -1,2 +1,3 @@
 export { pingNTimes } from "./ping-internet";
 export { getDatasets, getSingleDataset } from "./getDatasets";
+export { deleteDatasets } from "./deleteDatasets";

--- a/packages/application-server/src/actions.ts
+++ b/packages/application-server/src/actions.ts
@@ -10,6 +10,7 @@ import {
   PING_STATUS,
   PING_PERCENT_COMPLETE
 } from "./events/pingInternet";
+import { REQUEST_DELETE_DATASET } from "./events/datasets/deleteDataset";
 
 /**
  * Actions the main process is listening and responding to. These are instantiated after
@@ -20,6 +21,7 @@ import {
 export const MAIN_LISTENERS = [
   GET_PING_STATUS.listen,
   REQUEST_DATASETS.listen,
+  REQUEST_DELETE_DATASET.listen,
   REQUEST_SINGLE_DATASET.listen,
   START_PING.listen
 ];
@@ -31,6 +33,7 @@ export const MAIN_LISTENERS = [
 export const RENDERER_ACTIONS = {
   getPingStatus: GET_PING_STATUS.sendAction,
   requestDatasets: REQUEST_DATASETS.sendAction,
+  requestDeleteDataset: REQUEST_DELETE_DATASET.sendAction,
   requestSingleDataset: REQUEST_SINGLE_DATASET.sendAction,
   startPing: START_PING.sendAction
 };

--- a/packages/application-server/src/events/datasets/deleteDataset.ts
+++ b/packages/application-server/src/events/datasets/deleteDataset.ts
@@ -1,0 +1,23 @@
+import {
+  getDatasets,
+  deleteDatasets
+} from "@looking-glass/application-scripts";
+import { BasicAction } from "../../classes/basicActions";
+import { IDeleteDatasetsRequest } from "../../typings";
+import { GET_DATASETS } from "./getDataset";
+
+enum CHANNELS {
+  REQUEST_DELETE_DATASET = "request-delete-dataset"
+}
+
+export const REQUEST_DELETE_DATASET = new BasicAction<IDeleteDatasetsRequest>(
+  CHANNELS.REQUEST_DELETE_DATASET,
+  (event, { datasetNames }) => {
+    deleteDatasets(datasetNames);
+    const remainingDatasetNames = getDatasets();
+    event.sender.send(
+      GET_DATASETS.channel,
+      GET_DATASETS.verifyArgs({ datasetNames: remainingDatasetNames })
+    );
+  }
+);

--- a/packages/application-server/src/typings.ts
+++ b/packages/application-server/src/typings.ts
@@ -25,3 +25,7 @@ export type ISingleDataset = {
   datasetName: string;
   data: any;
 };
+
+export type IDeleteDatasetsRequest = {
+  datasetNames: string[];
+};

--- a/packages/interface/src/LookingGlass.tsx
+++ b/packages/interface/src/LookingGlass.tsx
@@ -15,6 +15,7 @@ import {
 import { IStoreState } from "./store/state";
 import { IRouteOption, IUrlOptions } from "./utils/typings";
 import { Flexbox } from "./common/flexbox";
+import { VerifyDialog } from "./common/verifyDialog";
 
 interface IOwnProps {
   /**
@@ -53,6 +54,7 @@ export class UnconnectedLookingGlass extends React.PureComponent<IProps> {
         <Flexbox className="fade-in" flex="1" key={url}>
           {this.renderCurrentRoutePage()}
         </Flexbox>
+        {this.renderGlobalDialogs()}
       </div>
     );
   }
@@ -72,6 +74,14 @@ export class UnconnectedLookingGlass extends React.PureComponent<IProps> {
       default:
         return null;
     }
+  }
+
+  private renderGlobalDialogs() {
+    return (
+      <>
+        <VerifyDialog />
+      </>
+    );
   }
 }
 

--- a/packages/interface/src/common/verifyDialog.tsx
+++ b/packages/interface/src/common/verifyDialog.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { Dialog, Button, Classes } from "@blueprintjs/core";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+import { IStoreState, CLOSE_VERIFY_DIALOG } from "../store";
+import { IVerifyDialogProps } from "../typings/store";
+
+interface IStateProps {
+  verifyDialogProps: IVerifyDialogProps | undefined;
+}
+
+interface IDispatchProps {
+  closeVerifyDialog: () => void;
+}
+
+type IProps = IStateProps & IDispatchProps;
+
+class UnconnectedVerifyDialog extends React.PureComponent<IProps> {
+  public render() {
+    const { closeVerifyDialog, verifyDialogProps } = this.props;
+
+    return (
+      <Dialog
+        canOutsideClickClose={false}
+        icon={verifyDialogProps?.icon}
+        isOpen={verifyDialogProps !== undefined}
+        onClose={closeVerifyDialog}
+        title={verifyDialogProps?.title}
+      >
+        <div className={Classes.DIALOG_BODY}>
+          {verifyDialogProps?.description}
+        </div>
+        <div className={Classes.DIALOG_FOOTER}>
+          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+            <Button
+              onClick={closeVerifyDialog}
+              text={verifyDialogProps?.cancelText || "Cancel"}
+            />
+            <Button
+              intent={verifyDialogProps?.confirmButtonIntent}
+              onClick={this.onConfirm}
+              text={verifyDialogProps?.confirmText || "Yes"}
+            />
+          </div>
+        </div>
+      </Dialog>
+    );
+  }
+
+  private onConfirm = () => {
+    const { verifyDialogProps } = this.props;
+    verifyDialogProps?.onConfirm();
+    CLOSE_VERIFY_DIALOG();
+  };
+}
+
+function mapStateToProps(state: IStoreState): IStateProps {
+  return {
+    verifyDialogProps: state.interface.verifyDialogProps
+  };
+}
+
+function mapDispatchToProps(dispatch: Dispatch): IDispatchProps {
+  return {
+    closeVerifyDialog: () => dispatch(CLOSE_VERIFY_DIALOG.create())
+  };
+}
+
+export const VerifyDialog = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(UnconnectedVerifyDialog);

--- a/packages/interface/src/components/collectData/pingInternet.tsx
+++ b/packages/interface/src/components/collectData/pingInternet.tsx
@@ -7,7 +7,7 @@ import {
 } from "@looking-glass/application-server";
 import { Button, ProgressBar } from "@blueprintjs/core";
 import { connect } from "react-redux";
-import { IStoreState } from "../../store/state";
+import { IStoreState } from "../../store";
 import { Flexbox } from "../../common/flexbox";
 
 interface IStateProps {

--- a/packages/interface/src/store/index.ts
+++ b/packages/interface/src/store/index.ts
@@ -1,2 +1,3 @@
 export * from "./application";
 export * from "./interface";
+export * from "./state";

--- a/packages/interface/src/store/interface/actions.ts
+++ b/packages/interface/src/store/interface/actions.ts
@@ -1,6 +1,15 @@
 import { TypedAction } from "redoodle";
 import { IRouteOption } from "../../utils/typings";
+import { IVerifyDialogProps } from "../../typings/store";
 
 export const SET_ROUTE = TypedAction.define("interface/set-route")<
   IRouteOption
 >();
+
+export const OPEN_VERIFY_DIALOG = TypedAction.define(
+  "interface/open-verify-dialog"
+)<IVerifyDialogProps>();
+
+export const CLOSE_VERIFY_DIALOG = TypedAction.defineWithoutPayload(
+  "interface/close-verify-dialog"
+)();

--- a/packages/interface/src/store/interface/reducer.ts
+++ b/packages/interface/src/store/interface/reducer.ts
@@ -1,15 +1,24 @@
 import { TypedReducer, setWith } from "redoodle";
 import { IRouteOption, IUrlOptions } from "../../utils/typings";
-import { SET_ROUTE } from "./actions";
+import { SET_ROUTE, CLOSE_VERIFY_DIALOG, OPEN_VERIFY_DIALOG } from "./actions";
+import { IVerifyDialogProps } from "../../typings/store";
 
 export interface IInterfaceState {
   route: IRouteOption;
+  verifyDialogProps: IVerifyDialogProps | undefined;
 }
 
 export const EMPTY_INTERFACE_STATE: IInterfaceState = {
-  route: { url: IUrlOptions.HOME }
+  route: { url: IUrlOptions.HOME },
+  verifyDialogProps: undefined
 };
 
 export const interfaceReducer = TypedReducer.builder<IInterfaceState>()
   .withHandler(SET_ROUTE.TYPE, (state, route) => setWith(state, { route }))
+  .withHandler(CLOSE_VERIFY_DIALOG.TYPE, state =>
+    setWith(state, { verifyDialogProps: undefined })
+  )
+  .withHandler(OPEN_VERIFY_DIALOG.TYPE, (state, verifyDialogProps) =>
+    setWith(state, { verifyDialogProps })
+  )
   .build();

--- a/packages/interface/src/typings/store.ts
+++ b/packages/interface/src/typings/store.ts
@@ -1,0 +1,12 @@
+import { IconName, Intent } from "@blueprintjs/core";
+import { ReactNode } from "react";
+
+export interface IVerifyDialogProps {
+  cancelText?: string;
+  confirmButtonIntent?: Intent;
+  confirmText?: string;
+  description: string | ReactNode;
+  icon?: IconName;
+  onConfirm: () => void;
+  title: string;
+}


### PR DESCRIPTION
Wires up the delete dataset button in the collect data route. This also adds a generic verify dialog that gets opened through dispatching a redux action.

## Screenshots
<img width="530" alt="Screen Shot 2020-01-24 at 6 51 17 PM" src="https://user-images.githubusercontent.com/12898578/73095461-8eee5c80-3eda-11ea-91cc-2fc41b1bce95.png">
<img width="409" alt="Screen Shot 2020-01-24 at 6 51 10 PM" src="https://user-images.githubusercontent.com/12898578/73095462-8eee5c80-3eda-11ea-84f3-0c7b5f41b122.png">
